### PR TITLE
Add inherited annotation on ResultRequiresPermission annotation so cl…

### DIFF
--- a/libs/micronaut-permissions/src/main/groovy/com/agorapulse/permissions/ResultRequiresPermission.java
+++ b/libs/micronaut-permissions/src/main/groovy/com/agorapulse/permissions/ResultRequiresPermission.java
@@ -22,6 +22,7 @@ import io.micronaut.context.annotation.Type;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -33,6 +34,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * and every check must pass.
  */
 @Around
+@Inherited
 @Documented
 @Retention(RUNTIME)
 @Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})

--- a/libs/micronaut-permissions/src/test/groovy/com/agorapulse/permissions/IPostService.java
+++ b/libs/micronaut-permissions/src/test/groovy/com/agorapulse/permissions/IPostService.java
@@ -1,3 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2023 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.agorapulse.permissions;
 
 import java.util.Collection;

--- a/libs/micronaut-permissions/src/test/groovy/com/agorapulse/permissions/IPostService.java
+++ b/libs/micronaut-permissions/src/test/groovy/com/agorapulse/permissions/IPostService.java
@@ -1,0 +1,31 @@
+package com.agorapulse.permissions;
+
+import java.util.Collection;
+import java.util.Map;
+
+public interface IPostService {
+
+    Post create(Long userId, String message);
+
+    @ResultRequiresPermission(value = "view")                                           // <2>
+    Post get(Long id);
+
+    @RequiresPermission("edit")
+    Post archive(Post post);
+
+    @RequiresPermission("edit")
+    void handleIterableContainer(Collection<Post> posts);
+
+    @RequiresPermission("edit")
+    void handleContainerNonIterable(Post post, Map<String, String> couldBeIterableContainer);
+
+    @RequiresPermission("edit")
+    Post publish(Post post);
+
+    @ResultRequiresPermission(value = "view", returnNull = true)                        // <3>
+    Post getOrEmpty(Long id);
+
+    @RequiresPermission("read")
+    Post merge(Long userId, Post post1, Post post2);
+
+}

--- a/libs/micronaut-permissions/src/test/groovy/com/agorapulse/permissions/PostController.java
+++ b/libs/micronaut-permissions/src/test/groovy/com/agorapulse/permissions/PostController.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 @Controller("/post")
 public class PostController {
 
-    private final PostService postService;
+    private final IPostService postService;
     private final PostRepository postRepository;
 
     public PostController(PostService postService, PostRepository postRepository) {

--- a/libs/micronaut-permissions/src/test/groovy/com/agorapulse/permissions/PostService.java
+++ b/libs/micronaut-permissions/src/test/groovy/com/agorapulse/permissions/PostService.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 import java.util.Map;
 
 @Singleton
-public class PostService {
+public class PostService implements IPostService {
 
     private final PostRepository postRepository;
 
@@ -30,6 +30,7 @@ public class PostService {
         this.postRepository = postRepository;
     }
 
+    @Override
     public Post create(Long userId, String message) {
         if (userId == null || userId == 0) {
             throw new IllegalArgumentException("User not specified");
@@ -37,36 +38,35 @@ public class PostService {
         return Post.createDraft(userId, message);
     }
 
-    @RequiresPermission("edit")                                                         // <1>
+    @Override                                                  // <1>
     public Post archive(Post post) {
         return post.archive();
     }
 
-    @RequiresPermission("edit")
+    @Override
     public void handleIterableContainer(Collection<Post> posts) {
     }
 
-    @RequiresPermission("edit")
+    @Override
     public void handleContainerNonIterable(Post post, Map<String, String> couldBeIterableContainer) {
     }
 
-
-    @RequiresPermission("edit")
+    @Override
     public Post publish(Post post) {
         return post.publish();
     }
 
-    @ResultRequiresPermission(value = "view")                                           // <2>
+    @Override
     public Post get(Long id) {
         return postRepository.get(id);
     }
 
-    @ResultRequiresPermission(value = "view", returnNull = true)                        // <3>
+    @Override
     public Post getOrEmpty(Long id) {
         return postRepository.get(id);
     }
 
-    @RequiresPermission("read")
+    @Override
     public Post merge(Long userId, Post post1, Post post2) {
         return Post.createDraft(userId, post1.getMessage() + post2.getMessage());
     }


### PR DESCRIPTION
Our use case in Publishing is that we often use an Interface to describe our service and classes implementing this interface to define the method. The annotation are on the interface so we need inheritance on this annotation.
I don't know if it was on purpose not to add `@Inherited` annotation on this Annotation.

- Add `@inherited` annotation on the `ResultRequiresPermission` annotation so inherited method from interfaces having this annotation will also trigger the interceptor.
- Updated the tests with an interface holding annotations and a classes implementing it to check interceptor are triggered.