### PR TITLE
Upgrade micronaut-permissions to Micronaut 5.x

### DIFF
--- a/.github/workflows/gradle-versions-watchdog.yml
+++ b/.github/workflows/gradle-versions-watchdog.yml
@@ -9,14 +9,12 @@ jobs:
     name: Verify the Latest Gradle Version
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-
-    - name: Setup Java 17
-      uses: actions/setup-java@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
       with:
-        distribution: corretto
-        java-version: 17
-    - uses: gradle/gradle-build-action@v2
+        java-version: 25
+        distribution: zulu
+    - uses: gradle/actions/setup-gradle@v5
       with:
-        arguments: check coveralls
         gradle-version: rc
+    - run: ./gradlew check

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright 2020-2022 Agorapulse.
+# Copyright 2020-2026 Agorapulse.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,15 +23,11 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
-    env:
-      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup Java 17
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
-          distribution: corretto
-          java-version: 17
-      - uses: gradle/gradle-build-action@v2
-        with:
-          arguments: check coveralls
+          java-version: 25
+          distribution: zulu
+      - uses: gradle/actions/setup-gradle@v5
+      - run: ./gradlew check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,19 +7,12 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    env:
-      GRADLE_OPTS: "-Xmx6g -Xms4g"
-      SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-      SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-      SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup Java 17
-        uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
-          distribution: corretto
-          java-version: 17
+          java-version: 25
+          distribution: zulu
       - name: Semantic Version
         id: version
         uses: ncipollo/semantic-version-action@v1
@@ -29,12 +22,19 @@ jobs:
         with:
           fileName: 'secret.pgp'
           encodedString: ${{ secrets.SIGNING_SECRET_KEY_BASE64 }}
+      - uses: gradle/actions/setup-gradle@v5
       - name: Release
         env:
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_SECRET_KEY_PATH: ${{ steps.write_file.outputs.filePath }}
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: -x groovydoc publishToSonatype closeAndReleaseSonatypeStagingRepository -Pversion=${{ steps.version.outputs.tag }} -Prelease=true  gitPublishPush -Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
+        run: |
+          ./gradlew :guide:gitPublishPush publishAndReleaseToMavenCentral \
+            -Pversion=${{ steps.version.outputs.tag }} \
+            -PmavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }} \
+            -PmavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }} \
+            -Prelease=true \
+            --stacktrace
   ping:
     if: ${{ !github.event.release.prerelease }}
     name: Notify Upstream Repositories
@@ -46,7 +46,7 @@ jobs:
           - agorapulse/agorapulse-bom
           - agorapulse/agorapulse-oss
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Semantic Version
         id: version
         uses: ncipollo/semantic-version-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,17 @@ jobs:
           fileName: 'secret.pgp'
           encodedString: ${{ secrets.SIGNING_SECRET_KEY_BASE64 }}
       - uses: gradle/actions/setup-gradle@v5
+      - name: Configure git identity for gitPublishCommit
+        run: |
+          git config --global user.name 'Agorapulse Bot'
+          git config --global user.email 'oss@agorapulse.com'
       - name: Release
         env:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_SECRET_KEY_PATH: ${{ steps.write_file.outputs.filePath }}
+          GIT_PUBLISH_USERNAME: agorapulse-bot
+          GIT_PUBLISH_PASSWORD: ${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
         run: |
           ./gradlew :guide:gitPublishPush publishAndReleaseToMavenCentral \
             -Pversion=${{ steps.version.outputs.tag }} \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           arguments: -x groovydoc publishToSonatype closeAndReleaseSonatypeStagingRepository -Pversion=${{ steps.version.outputs.tag }} -Prelease=true  gitPublishPush -Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
   ping:
+    if: ${{ !github.event.release.prerelease }}
     name: Notify Upstream Repositories
     runs-on: ubuntu-latest
     needs: [release]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,4 +56,4 @@ jobs:
           token: ${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
           repository: ${{ matrix.repository }}
           event-type: ap-new-version-released-event
-          client-payload: '{ "group": "com.agorapulse", "module": "micronaut-permissions", "micronautCompatibility": [4], "version": "${{ steps.version.outputs.tag }}", "property" : "micronaut.permissions.version", "github" : ${{ toJson(github) }} }'
+          client-payload: '{ "group": "com.agorapulse", "module": "micronaut-permissions", "micronautCompatibility": [5], "version": "${{ steps.version.outputs.tag }}", "property" : "micronaut.permissions.version", "github" : ${{ toJson(github) }} }'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://github.com/agorapulse/micronaut-permissions/workflows/Check/badge.svg)](https://github.com/agorapulse/micronaut-permissions/actions)
 [![Maven Central](https://img.shields.io/maven-central/v/com.agorapulse/micronaut-permissions.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.agorapulse%22%20AND%20a:%22micronaut-permissions%22)
-[![Coverage Status](https://coveralls.io/repos/github/agorapulse/micronaut-permissions/badge.svg?branch=master)](https://coveralls.io/github/agorapulse/micronaut-permissions?branch=master)
 
 Micronaut Permissions provides a lightweight library to declare object level permissions in Micronaut which can be declared on any service and which are not limited to HTTP environment.
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,6 @@
  */
 plugins {
     id 'lifecycle-base'
-    id 'com.agorapulse.gradle.aggregate-test-reports'   version "${agorapulseAggregateReportsVersion}"
-    id 'com.agorapulse.gradle.aggregate-jacoco-reports' version "${agorapulseGradlePluginsVersion}"
 }
 
 if (!project.hasProperty('mavenCentralUsername'))       ext.mavenCentralUsername       = System.getenv('MAVEN_CENTRAL_USERNAME') ?: '**UNDEFINED**'
@@ -81,8 +79,4 @@ subprojects {
             sign publishing.publications
         }
     }
-}
-
-tasks.named('check') {
-    dependsOn 'aggregateTestReports', 'aggregateJacocoReports'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 plugins {
+    id 'lifecycle-base'
     id 'com.agorapulse.gradle.aggregate-test-reports'   version "${agorapulseAggregateReportsVersion}"
     id 'com.agorapulse.gradle.aggregate-jacoco-reports' version "${agorapulseGradlePluginsVersion}"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,12 @@ plugins {
     id 'com.agorapulse.gradle.aggregate-jacoco-reports' version "${agorapulseGradlePluginsVersion}"
 }
 
+if (!project.hasProperty('mavenCentralUsername'))       ext.mavenCentralUsername       = System.getenv('MAVEN_CENTRAL_USERNAME') ?: '**UNDEFINED**'
+if (!project.hasProperty('mavenCentralPassword'))       ext.mavenCentralPassword       = System.getenv('MAVEN_CENTRAL_PASSWORD') ?: '**UNDEFINED**'
+if (!project.hasProperty('signingInMemoryKeyId'))       ext.signingInMemoryKeyId       = System.getenv('SIGNING_KEY_ID') ?: '**UNDEFINED**'
+if (!project.hasProperty('signingInMemoryKeyPassword')) ext.signingInMemoryKeyPassword = System.getenv('SIGNING_PASSWORD') ?: '**UNDEFINED**'
+if (!project.hasProperty('signingInMemoryKey'))         ext.signingInMemoryKey         = System.getenv('SIGNING_SECRET_KEY_PATH') ? rootProject.file(System.getenv('SIGNING_SECRET_KEY_PATH')).text : '**UNDEFINED**'
+
 allprojects {
     repositories {
         mavenCentral()
@@ -34,6 +40,44 @@ subprojects {
             processing {
                 incremental false
             }
+        }
+    }
+
+    plugins.withId('com.vanniktech.maven.publish') {
+        mavenPublishing {
+            publishToMavenCentral(true)
+            signAllPublications()
+
+            pom {
+                name = 'Micronaut Permissions'
+                description = 'Method-level role-based permissions for Micronaut applications'
+                inceptionYear = '2020'
+                url = "https://github.com/${slug}"
+                licenses {
+                    license {
+                        name = 'The Apache License, Version 2.0'
+                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'musketyr'
+                        name = 'Vladimir Orany'
+                        url = 'https://github.com/musketyr/'
+                    }
+                }
+                scm {
+                    url = "https://github.com/${slug}.git"
+                    connection = "scm:git:git://github.com/${slug}.git"
+                    developerConnection = "scm:git:ssh://git@github.com/${slug}.git"
+                }
+            }
+        }
+
+        signing {
+            useInMemoryPgpKeys(rootProject.ext.signingInMemoryKey, rootProject.ext.signingInMemoryKeyPassword)
+            sign publishing.publications
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2023 Agorapulse.
+ * Copyright 2023-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,187 +16,28 @@
  * limitations under the License.
  */
 plugins {
-    id 'org.kordamp.gradle.groovy-project'
-    id 'org.kordamp.gradle.checkstyle'
-    id 'org.kordamp.gradle.codenarc'
-    id 'org.kordamp.gradle.coveralls'
-    id 'io.github.gradle-nexus.publish-plugin'
-}
-
-if (!project.hasProperty('ossrhUsername'))      ext.ossrhUsername       = System.getenv('SONATYPE_USERNAME') ?: '**UNDEFINED**'
-if (!project.hasProperty('ossrhPassword'))      ext.ossrhPassword       = System.getenv('SONATYPE_PASSWORD') ?: '**UNDEFINED**'
-if (!project.hasProperty('signingKeyId'))       ext.signingKeyId        = System.getenv('SIGNING_KEY_ID') ?: '**UNDEFINED**'
-if (!project.hasProperty('signingPassword'))    ext.signingPassword     = System.getenv('SIGNING_PASSWORD') ?: '**UNDEFINED**'
-if (!project.hasProperty('signingSecretKey'))   ext.signingSecretKey    = System.getenv('SIGNING_SECRET_KEY_PATH') ? rootProject.file(System.getenv('SIGNING_SECRET_KEY_PATH')).text : '**UNDEFINED**'
-
-config {
-    release = (rootProject.findProperty('release') ?: false).toBoolean()
-
-    info {
-        name        = 'Micronaut Permissions'
-        vendor      = 'Agorapulse'
-        description = 'Micronaut Permissions Library'
-
-        links {
-            website      = "https://github.com/" + slug
-            issueTracker = "https://github.com/" + slug + "/issues"
-            scm          = "https://github.com/" + slug + ".git"
-        }
-
-        people {
-            person {
-                id    = 'musketyr'
-                name  = 'Vladimir Orany'
-                roles = ['developer']
-            }
-        }
-
-        repositories {
-            repository {
-                name = 'localRelease'
-                url  = "" + project.rootProject.buildDir + "/repos/local/release"
-            }
-            repository {
-                name = 'localSnapshot'
-                url  = "" + project.rootProject.buildDir + "/repos/local/snapshot"
-            }
-        }
-    }
-
-    licensing {
-        licenses {
-            license {
-                id = 'Apache-2.0'
-            }
-        }
-    }
-
-    publishing {
-        enabled = false
-        signing {
-            enabled = true
-            keyId = signingKeyId
-            secretKey = signingSecretKey
-            password = signingPassword
-        }
-        releasesRepository  = 'localRelease'
-        snapshotsRepository = 'localSnapshot'
-    }
-
-    quality {
-        checkstyle {
-            toolVersion = '8.27'
-        }
-
-        codenarc {
-            toolVersion = '1.5'
-        }
-    }
-
-    docs {
-        javadoc {
-            aggregate {
-                enabled = false
-            }
-            autoLinks {
-                enabled = false
-            }
-        }
-        groovydoc {
-            enabled = false
-            aggregate {
-                enabled = false
-            }
-        }
-    }
-
-}
-
-nexusPublishing {
-    repositories {
-        sonatype {
-            nexusUrl = uri('https://s01.oss.sonatype.org/service/local/')
-            snapshotRepositoryUrl = uri('https://s01.oss.sonatype.org/content/repositories/snapshots/')
-            username = ossrhUsername
-            password = ossrhPassword
-        }
-    }
+    id 'com.agorapulse.gradle.aggregate-test-reports'   version "${agorapulseAggregateReportsVersion}"
+    id 'com.agorapulse.gradle.aggregate-jacoco-reports' version "${agorapulseGradlePluginsVersion}"
 }
 
 allprojects {
     repositories {
         mavenCentral()
     }
-
-    license {
-        exclude '**/*.json'
-        exclude '***.yml'
-    }
 }
 
-gradleProjects {
-    subprojects {
-        dirs(['libs']) { Project subproject ->
-            micronaut {
-                importMicronautPlatform = true
-                testRuntime 'spock2'
-                processing {
-                    incremental false
-                }
-            }
-
-            java {
-                toolchain {
-                    languageVersion = JavaLanguageVersion.of(17)
-                }
-            }
-
-            repositories {
-                mavenCentral()
-            }
-
-            // location independent tests (useful for stable CI builds)
-            tasks.withType(Test) {
-                useJUnitPlatform()
-
-                systemProperty 'user.timezone', 'UTC'
-                systemProperty 'user.language', 'en'
-            }
-
-            tasks.withType(JavaCompile) {
-                options.encoding = "UTF-8"
-                options.compilerArgs.add('-parameters')
-            }
-
-            tasks.withType(GroovyCompile) {
-                groovyOptions.forkOptions.jvmArgs.add('-Dgroovy.parameters=true')
-            }
-
-            // useful for IntelliJ
-            task cleanOut(type: Delete) {
-                delete file('out')
-            }
-
-            clean.dependsOn cleanOut
-
-            processResources {
-                filesMatching('**/org.codehaus.groovy.runtime.ExtensionModule') {
-                    filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: [VERSION: version])
-                }
-            }
-
-            jar {
-                manifest.attributes provider: 'gradle'
-            }
-
-            config {
-                publishing {
-                    enabled = true
-                }
+subprojects {
+    plugins.withId('com.agorapulse.gradle.micronaut-library') {
+        micronaut {
+            importMicronautPlatform = true
+            testRuntime 'spock'
+            processing {
+                incremental false
             }
         }
     }
 }
 
-
-check.dependsOn('aggregateCheckstyle', 'aggregateCodenarc', 'aggregateAllTestReports', 'coveralls')
+tasks.named('check') {
+    dependsOn 'aggregateTestReports', 'aggregateJacocoReports'
+}

--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -19,6 +19,14 @@ plugins {
     id 'com.agorapulse.gradle.guide'
 }
 
+// gradle-git-publish 5.x no longer reads GRGIT_USER / GRGIT_PASS env vars
+// (or the org.ajoberstar.grgit.auth.* system properties). HTTPS push
+// credentials must be set on the gitPublish extension directly.
+gitPublish {
+    username = providers.environmentVariable('GIT_PUBLISH_USERNAME').orElse('')
+    password = providers.environmentVariable('GIT_PUBLISH_PASSWORD').orElse('')
+}
+
 asciidoctor {
     baseDirFollowsSourceDir()
 

--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2023 Agorapulse.
+ * Copyright 2023-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,31 +16,10 @@
  * limitations under the License.
  */
 plugins {
-    id 'org.kordamp.gradle.guide'
-    id 'org.ajoberstar.git-publish'
-}
-
-config {
-    docs {
-        guide {
-            publish {
-                enabled = true
-            }
-        }
-    }
-}
-
-configurations {
-    asciidoctorExtensions
-}
-
-dependencies {
-    asciidoctorExtensions 'com.bmuschko:asciidoctorj-tabbed-code-extension:0.3'
+    id 'com.agorapulse.gradle.guide'
 }
 
 asciidoctor {
-    configurations 'asciidoctorExtensions'
-
     baseDirFollowsSourceDir()
 
     attributes = [
@@ -49,5 +28,4 @@ asciidoctor {
         'root-dir': rootDir,
         'project-slug': slug
     ]
-
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,6 @@ version=3.0.0-SNAPSHOT
 javaVersion = 25
 
 agorapulseGradlePluginsVersion = 4.4.2
-agorapulseAggregateReportsVersion = 4.0.0-rc3
 mavenCentralPublishPluginVersion = 0.34.0
 develocityPluginVersion = 4.2.2
 gitPublishPluginVersion=2.1.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,6 +27,7 @@ javaVersion = 25
 agorapulseGradlePluginsVersion = 4.4.2
 agorapulseAggregateReportsVersion = 4.0.0-rc3
 mavenCentralPublishPluginVersion = 0.34.0
+develocityPluginVersion = 4.2.2
 gitPublishPluginVersion=2.1.3
 
 micronautVersion = 5.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ javaVersion = 25
 
 agorapulseGradlePluginsVersion = 4.4.2
 agorapulseAggregateReportsVersion = 4.0.0-rc3
-nexusPluginVersion=1.0.0
+mavenCentralPublishPluginVersion = 0.34.0
 gitPublishPluginVersion=2.1.3
 
 micronautVersion=4.2.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright 2023 Agorapulse.
+# Copyright 2023-2026 Agorapulse.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,18 @@
 # limitations under the License.
 #
 
+org.gradle.caching=true
+
 slug=agorapulse/micronaut-permissions
 group=com.agorapulse
 version=3.0.0-SNAPSHOT
-kordampPluginVersion=0.51.0
+
+javaVersion = 25
+
+agorapulseGradlePluginsVersion = 4.4.2
+agorapulseAggregateReportsVersion = 4.0.0-rc3
 nexusPluginVersion=1.0.0
 gitPublishPluginVersion=2.1.3
 
-micronautGradlePluginVersion = 4.2.0
 micronautVersion=4.2.0
+micronautGradlePluginVersion = 4.2.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,5 +29,5 @@ agorapulseAggregateReportsVersion = 4.0.0-rc3
 mavenCentralPublishPluginVersion = 0.34.0
 gitPublishPluginVersion=2.1.3
 
-micronautVersion=4.2.0
-micronautGradlePluginVersion = 4.2.0
+micronautVersion = 5.0.0
+micronautGradlePluginVersion = 5.0.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/libs/micronaut-permissions/micronaut-permissions.gradle
+++ b/libs/micronaut-permissions/micronaut-permissions.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2023 Agorapulse.
+ * Copyright 2023-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libs/micronaut-permissions/src/main/groovy/com/agorapulse/permissions/DefaultPermissionChecker.java
+++ b/libs/micronaut-permissions/src/main/groovy/com/agorapulse/permissions/DefaultPermissionChecker.java
@@ -65,8 +65,9 @@ public class DefaultPermissionChecker implements PermissionChecker {
         if (value == null) {
             return PermissionCheckResult.ALLOW;
         }
+        Argument<T> itemType = (Argument<T>) valueType.getTypeParameters()[0];
         for (T item : value) {
-            switch (checkPermission(permissionDefinition, item, valueType.getTypeParameters()[0])) {
+            switch (checkPermission(permissionDefinition, item, itemType)) {
                 case DENY:
                     return PermissionCheckResult.DENY;
                 case UNKNOWN:

--- a/settings.gradle
+++ b/settings.gradle
@@ -44,9 +44,16 @@ buildscript {
 }
 
 plugins {
-    id 'com.agorapulse.gradle.settings'             version "${agorapulseGradlePluginsVersion}"
-    id 'com.agorapulse.gradle.gradle-enterprise'    version "${agorapulseGradlePluginsVersion}"
-    id 'com.agorapulse.gradle.remote-cache'         version "${agorapulseGradlePluginsVersion}"
+    id 'com.agorapulse.gradle.settings' version "${agorapulseGradlePluginsVersion}"
+    id 'com.gradle.develocity'          version "${develocityPluginVersion}"
+}
+
+develocity {
+    buildScan {
+        termsOfUseUrl = 'https://gradle.com/terms-of-service'
+        termsOfUseAgree = 'yes'
+        publishing.onlyIf { true }
+    }
 }
 
 gradleProjects {

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,6 +26,7 @@ pluginManagement {
         id 'com.agorapulse.gradle.groovy-common-configuration' version "${agorapulseGradlePluginsVersion}"
         id 'com.agorapulse.gradle.micronaut-compatibility'     version "${agorapulseGradlePluginsVersion}"
         id 'com.agorapulse.gradle.guide'                       version "${agorapulseGradlePluginsVersion}"
+        id 'com.vanniktech.maven.publish'                      version "${mavenCentralPublishPluginVersion}"
     }
 }
 
@@ -38,6 +39,7 @@ buildscript {
         classpath group: 'io.micronaut.gradle',   name: 'micronaut-minimal-plugin',     version: micronautGradlePluginVersion
         classpath group: 'com.agorapulse.gradle', name: 'micronaut-library',            version: agorapulseGradlePluginsVersion
         classpath group: 'com.agorapulse.gradle', name: 'groovy-common-configuration',  version: agorapulseGradlePluginsVersion
+        classpath group: 'com.vanniktech',        name: 'gradle-maven-publish-plugin',  version: mavenCentralPublishPluginVersion
     }
 }
 
@@ -55,6 +57,7 @@ gradleProjects {
             id 'groovy'
             id 'com.agorapulse.gradle.micronaut-library'
             id 'com.agorapulse.gradle.groovy-common-configuration'
+            id 'com.vanniktech.maven.publish'
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright 2023 Agorapulse.
+ * Copyright 2023-2026 Agorapulse.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,51 +15,48 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        maven { url 'https://agorapulse.jfrog.io/agorapulse/gradle-plugins-releases-local/' }
+        mavenCentral()
+    }
+    plugins {
+        id 'com.agorapulse.gradle.micronaut-library'           version "${agorapulseGradlePluginsVersion}"
+        id 'com.agorapulse.gradle.groovy-common-configuration' version "${agorapulseGradlePluginsVersion}"
+        id 'com.agorapulse.gradle.micronaut-compatibility'     version "${agorapulseGradlePluginsVersion}"
+        id 'com.agorapulse.gradle.guide'                       version "${agorapulseGradlePluginsVersion}"
+    }
+}
+
 buildscript {
     repositories {
-        mavenCentral()
         gradlePluginPortal()
+        maven { url 'https://agorapulse.jfrog.io/agorapulse/gradle-plugins-releases-local/' }
     }
     dependencies {
-        classpath group: 'org.kordamp.gradle',          name: 'settings-gradle-plugin',         version: kordampPluginVersion
-        classpath group: 'org.kordamp.gradle',          name: 'groovy-project-gradle-plugin',   version: kordampPluginVersion
-        classpath group: 'org.kordamp.gradle',          name: 'checkstyle-gradle-plugin',       version: kordampPluginVersion
-        classpath group: 'org.kordamp.gradle',          name: 'codenarc-gradle-plugin',         version: kordampPluginVersion
-        classpath group: 'org.kordamp.gradle',          name: 'guide-gradle-plugin',            version: kordampPluginVersion
-        classpath group: 'org.kordamp.gradle',          name: 'coveralls-gradle-plugin',        version: kordampPluginVersion
-        classpath group: 'org.ajoberstar',              name: 'gradle-git-publish',             version: gitPublishPluginVersion
-        classpath group: 'io.github.gradle-nexus',      name: 'publish-plugin',                 version: nexusPluginVersion
-        classpath group: 'io.micronaut.gradle',         name: 'micronaut-minimal-plugin',      version: micronautGradlePluginVersion
+        classpath group: 'io.micronaut.gradle',   name: 'micronaut-minimal-plugin',     version: micronautGradlePluginVersion
+        classpath group: 'com.agorapulse.gradle', name: 'micronaut-library',            version: agorapulseGradlePluginsVersion
+        classpath group: 'com.agorapulse.gradle', name: 'groovy-common-configuration',  version: agorapulseGradlePluginsVersion
     }
 }
 
 plugins {
-    id 'org.kordamp.gradle.settings' version "$kordampPluginVersion"
-    id 'com.gradle.enterprise' version '3.6.1'
+    id 'com.agorapulse.gradle.settings'             version "${agorapulseGradlePluginsVersion}"
+    id 'com.agorapulse.gradle.gradle-enterprise'    version "${agorapulseGradlePluginsVersion}"
+    id 'com.agorapulse.gradle.remote-cache'         version "${agorapulseGradlePluginsVersion}"
 }
 
-gradleEnterprise {
-    buildScan {
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
+gradleProjects {
+    directories = ['libs', 'docs']
 
-        publishAlways()
+    plugins {
+        dirs(['libs']) {
+            id 'groovy'
+            id 'com.agorapulse.gradle.micronaut-library'
+            id 'com.agorapulse.gradle.groovy-common-configuration'
+        }
     }
 }
 
 rootProject.name = 'micronaut-permissions-root'
-
-projects {
-    directories = ['libs', 'docs']
-
-    plugins {
-        dir('docs') {
-            id 'org.kordamp.gradle.guide'
-            id 'org.ajoberstar.git-publish'
-        }
-        dirs(['libs']) {
-            id 'groovy'
-            id 'io.micronaut.minimal.library'
-        }
-    }
-}


### PR DESCRIPTION
## Micronaut 5.x upgrade

Brings `micronaut-permissions` to the Micronaut Framework 5.0 baseline (Java 25, Gradle 9.5, Groovy 5, Spock 2.4-groovy-5.0).

## What changed

### Build
- Bumped `micronautVersion` and the Micronaut Gradle plugin to `5.0.0`.
- Gradle wrapper bumped to `9.5.0`; Java toolchain pinned to 25 via `javaVersion=25`.
- Replaced the Kordamp Gradle plugins (`org.kordamp.gradle.*` — unmaintained since 0.54.0 in 2022 and incompatible with Gradle 9.5) with `com.agorapulse.gradle.*` convention plugins (`settings`, `micronaut-library`, `groovy-common-configuration`, `micronaut-compatibility`, `guide`).
- Switched build-scan publishing to the public Develocity (`com.gradle.develocity` -> `gradle.com`).
- Dropped per-library aggregate-test/jacoco-report tasks — the Develocity scan now aggregates everything. Coveralls is gone for the same reason; the README badge has been removed.
- Enabled the local Gradle build cache and restored `lifecycle-base` at the root so `./gradlew check` evaluates cleanly on Gradle 9.

### Publishing
- Replaced `io.github.gradle-nexus.publish-plugin` (legacy OSSRH `s01.oss.sonatype.org`, being deprecated by Sonatype) with `com.vanniktech.maven.publish` 0.34.0 publishing through the new Central Portal.
- Centralised the `mavenPublishing { publishToMavenCentral(true); signAllPublications(); pom { ... } }` + `signing { useInMemoryPgpKeys(...) }` block in the root build so the subproject build file collapses back to just its dependencies.
- Release workflow task simplified from `publishToSonatype` + `closeAndReleaseSonatypeStagingRepository` to the single `publishAndReleaseToMavenCentral`. Credentials are now passed as the standard `MAVEN_CENTRAL_USERNAME` / `MAVEN_CENTRAL_PASSWORD` Gradle properties.

### Release workflow
- Modernised actions: `actions/checkout@v4`, `actions/setup-java@v4` (Java 25, Zulu), `gradle/actions/setup-gradle@v5` instead of the deprecated `gradle/gradle-command-action@v2`.
- The downstream `ping` job is now gated on `!github.event.release.prerelease` so RC / SNAPSHOT releases don't notify consumers.
- Marks the artifact as Micronaut 5-compatible in the downstream notification payload.
- Configures a `Agorapulse Bot` git identity before `gitPublishCommit`, and passes the bot's `GIT_PUBLISH_USERNAME` / `GIT_PUBLISH_PASSWORD` directly to the `gitPublish` extension — required by gradle-git-publish 5.x which no longer reads the legacy `GRGIT_USER` / `GRGIT_PASS` env vars or the `org.ajoberstar.grgit.auth.*` system properties.

### Source
- `DefaultPermissionChecker.checkPermissionOnContainer` now captures the inner wildcard `Argument<?>` into a local `Argument<T>` before calling `PermissionChecker.checkPermission(String, T, Argument<T>)`. JDK 25's stricter overload resolution would otherwise pick the `<E extends Enum<E>>` overload and fail compilation. Pure refactor — no behaviour change.

## Required repository secrets

- `MAVEN_CENTRAL_USERNAME`
- `MAVEN_CENTRAL_PASSWORD`

Old `SONATYPE_USERNAME` / `SONATYPE_PASSWORD` are no longer referenced and can be removed after the first verified release.

## Test plan
- [ ] CI `Check` workflow is green on Java 25
- [ ] Publishing a pre-release tag does not trigger the downstream `ping` job
- [ ] Publishing a stable tag pings `agorapulse-bom` and `agorapulse-oss`